### PR TITLE
XBeeAddress64 improvements

### DIFF
--- a/XBee.cpp
+++ b/XBee.cpp
@@ -1014,53 +1014,6 @@ void PayloadRequest::setPayloadLength(uint8_t payloadLength) {
 	_payloadLength = payloadLength;
 }
 
-
-XBeeAddress::XBeeAddress() {
-
-}
-
-XBeeAddress64::XBeeAddress64() : XBeeAddress() {
-
-}
-
-XBeeAddress64::XBeeAddress64(uint32_t msb, uint32_t lsb) : XBeeAddress() {
-	_msb = msb;
-	_lsb = lsb;
-}
-
-XBeeAddress64::XBeeAddress64(uint64_t addr) : XBeeAddress() {
-	set(addr);
-}
-
-uint32_t XBeeAddress64::getMsb() {
-	return _msb;
-}
-
-void XBeeAddress64::setMsb(uint32_t msb) {
-	_msb = msb;
-}
-
-uint32_t XBeeAddress64::getLsb() {
-	return _lsb;
-}
-
-void XBeeAddress64::setLsb(uint32_t lsb) {
-	_lsb = lsb;
-}
-
-uint64_t XBeeAddress64::get() {
-	return (static_cast<uint64_t>(_msb) << 32) | _lsb;
-}
-
-void XBeeAddress64::set(uint64_t addr) {
-	_msb = addr >> 32;
-	_lsb = addr;
-}
-
-XBeeAddress64::operator uint64_t() {
-	return get();
-}
-
 #ifdef SERIES_2
 
 ZBTxRequest::ZBTxRequest() : PayloadRequest(ZB_TX_REQUEST, DEFAULT_FRAME_ID, NULL, 0) {

--- a/XBee.cpp
+++ b/XBee.cpp
@@ -1028,6 +1028,10 @@ XBeeAddress64::XBeeAddress64(uint32_t msb, uint32_t lsb) : XBeeAddress() {
 	_lsb = lsb;
 }
 
+XBeeAddress64::XBeeAddress64(uint64_t addr) : XBeeAddress() {
+	set(addr);
+}
+
 uint32_t XBeeAddress64::getMsb() {
 	return _msb;
 }
@@ -1044,14 +1048,18 @@ void XBeeAddress64::setLsb(uint32_t lsb) {
 	_lsb = lsb;
 }
 
-// contributed by user repat123 on issue tracker
-//bool XBeeAddress64::operator==(XBeeAddress64 addr) {
-//    return ((_lsb == addr.getLsb()) && (_msb == addr.getMsb()));
-//}
+uint64_t XBeeAddress64::get() {
+	return (static_cast<uint64_t>(_msb) << 32) | _lsb;
+}
 
-//bool XBeeAddress64::operator!=(XBeeAddress64 addr) {
-//            return !(*this == addr);
-//}
+void XBeeAddress64::set(uint64_t addr) {
+	_msb = addr >> 32;
+	_lsb = addr;
+}
+
+XBeeAddress64::operator uint64_t() {
+	return get();
+}
 
 #ifdef SERIES_2
 

--- a/XBee.h
+++ b/XBee.h
@@ -292,18 +292,26 @@ public:
 
 /**
  * Represents a 64-bit XBee Address
+ *
+ * Note that avr-gcc as of 4.9 doesn't optimize uint64_t very well, so
+ * for the smallest and fastest code, use msb and lsb separately. See
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66511
  */
 class XBeeAddress64 : public XBeeAddress {
 public:
+	XBeeAddress64(uint64_t addr);
 	XBeeAddress64(uint32_t msb, uint32_t lsb);
 	XBeeAddress64();
 	uint32_t getMsb();
 	uint32_t getLsb();
+	uint64_t get();
+	operator uint64_t();
 	void setMsb(uint32_t msb);
 	void setLsb(uint32_t lsb);
-	//bool operator==(XBeeAddress64 addr);
-	//bool operator!=(XBeeAddress64 addr);
+	void set(uint64_t addr);
 private:
+	// Once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66511 is
+	// fixed, it might make sense to merge these into a uint64_t.
 	uint32_t _msb;
 	uint32_t _lsb;
 };

--- a/XBee.h
+++ b/XBee.h
@@ -143,6 +143,20 @@
 #define UNEXPECTED_START_BYTE 3
 
 /**
+ * C++11 introduced the constexpr as a hint to the compiler that things
+ * can be evaluated at compiletime. This can help to remove
+ * startup code for global objects, or otherwise help the compiler to
+ * optimize. Since the keyword is introduced in C++11, but supporting
+ * older compilers is a matter of removing the keyword, we use a macro
+ * for this.
+ */
+#if __cplusplus >= 201103L
+#define CONSTEXPR constexpr
+#else
+#define CONSTEXPR
+#endif
+
+/**
  * The super class of all XBee responses (RX packets)
  * Users should never attempt to create an instance of this class; instead
  * create an instance of a subclass
@@ -287,7 +301,7 @@ private:
 
 class XBeeAddress {
 public:
-	XBeeAddress() {};
+	CONSTEXPR XBeeAddress() {};
 };
 
 /**
@@ -299,9 +313,9 @@ public:
  */
 class XBeeAddress64 : public XBeeAddress {
 public:
-	XBeeAddress64(uint64_t addr) : _msb(addr >> 32), _lsb(addr) {}
-	XBeeAddress64(uint32_t msb, uint32_t lsb) : _msb(msb), _lsb(lsb) {}
-	XBeeAddress64() {}
+	CONSTEXPR XBeeAddress64(uint64_t addr) : _msb(addr >> 32), _lsb(addr) {}
+	CONSTEXPR XBeeAddress64(uint32_t msb, uint32_t lsb) : _msb(msb), _lsb(lsb) {}
+	CONSTEXPR XBeeAddress64() : _msb(0), _lsb(0) {}
 	uint32_t getMsb() {return _msb;}
 	uint32_t getLsb() {return _lsb;}
 	uint64_t get() {return (static_cast<uint64_t>(_msb) << 32) | _lsb;}

--- a/XBee.h
+++ b/XBee.h
@@ -287,7 +287,7 @@ private:
 
 class XBeeAddress {
 public:
-	XBeeAddress();
+	XBeeAddress() {};
 };
 
 /**
@@ -299,16 +299,19 @@ public:
  */
 class XBeeAddress64 : public XBeeAddress {
 public:
-	XBeeAddress64(uint64_t addr);
-	XBeeAddress64(uint32_t msb, uint32_t lsb);
-	XBeeAddress64();
-	uint32_t getMsb();
-	uint32_t getLsb();
-	uint64_t get();
-	operator uint64_t();
-	void setMsb(uint32_t msb);
-	void setLsb(uint32_t lsb);
-	void set(uint64_t addr);
+	XBeeAddress64(uint64_t addr) : _msb(addr >> 32), _lsb(addr) {}
+	XBeeAddress64(uint32_t msb, uint32_t lsb) : _msb(msb), _lsb(lsb) {}
+	XBeeAddress64() {}
+	uint32_t getMsb() {return _msb;}
+	uint32_t getLsb() {return _lsb;}
+	uint64_t get() {return (static_cast<uint64_t>(_msb) << 32) | _lsb;}
+	operator uint64_t() {return get();}
+	void setMsb(uint32_t msb) {_msb = msb;}
+	void setLsb(uint32_t lsb) {_lsb = lsb;}
+	void set(uint64_t addr) {
+		_msb = addr >> 32;
+		_lsb = addr;
+	}
 private:
 	// Once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66511 is
 	// fixed, it might make sense to merge these into a uint64_t.


### PR DESCRIPTION
This implements the suggestions from #3, and a bit more. The commit logs have more info, but roughly:
 - This allows converting XBeeAddress64 to and from uint64_t transparently
 - This optimizes the XBeeAddress64 class

All existing API is still supported, working, and should not any slower or bigger. These changes have been compile-tested against all examples, as well as runtime-tested with my own programs.

The new APIs using uint64_t *are* significantly bigger and slower than the existing APIs, because the compiler [doesn't properly optimize uint64_t operations](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66511), so none of the other code and examples have been updated to use the new APIs yet.

I have a few more improvements planned (#5). If this PR is merged already, I'll open a new one, otherwise I'll append those here.

Closes #3.