### PR TITLE
Add library.properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=XBee-Arduino library
+version=0.5.0
+author=Andrew Wrapp
+maintainer=Andrew Wrapp <andrew.wrapp@gmail.com>
+sentence=Library for talking to to various wireless XBee modules from Digi.
+paragraph=This supports various devices, configured to use the more advanced "API" mode.
+category=Communication
+url=https://github.com/andrewrapp/xbee-arduino
+architectures=*


### PR DESCRIPTION
This turns the library into a proper non-legacy library and allows the
Arduino IDE to display some additional info in its library manager. This
also opens up the way to allow installing the library from within the
Arduino IDE, if the library's github url is added to the list of
libraries by the Arduino team.

This fixes the first part of issue #2.